### PR TITLE
fix(lib/Canvas): fix onload not triggerd

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -66,7 +66,7 @@ var Canvas = createReactClass({
                     automaticallyAdjustContentInsets={false}
                     scalesPageToFit={Platform.OS === 'android'}
                     contentInset={{top: 0, right: 0, bottom: 0, left: 0}}
-                    source={{ html: getRenderHTML(contextString, renderString, generate) }}
+                    source={{ html: getRenderHTML(contextString, renderString, generate), baseUrl: '' }}
                     opaque={false}
                     underlayColor={'transparent'}
                     style={this.props.style}


### PR DESCRIPTION
Fix the issue where `onLoad` and `onLoadEnd` were not triggered after the view was loaded. This
happens because `url` is `about://(null)` in iOS when using `html` in source like this: `source={{
html }}`. Setting the `baseUrl` parameter on the prop fixes the issue.

For reference :
https://github.com/facebook/react-native/issues/18802#issuecomment-401764616

resolve #2